### PR TITLE
Pass options.headers send from the client to knox-mpu

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,7 @@ module.exports = function SkipperS3 (globalOpts) {
         stream: __newFile,
         maxUploadSize: options.maxBytes,
         tmpDir: options.tmpdir,
+        headers: options.headers,
         client: knox.createClient({
           key: options.key,
           secret: options.secret,


### PR DESCRIPTION
I think this can also solve this (closed) https://github.com/balderdashy/skipper-s3/issues/1
This way when a user sends headers like this:
      bucket: process.env.S3_BUCKET_NAME,
      key: process.env.AWS_ACCESS_KEY_ID,
      secret: process.env.AWS_SECRET_ACCESS_KEY,
      headers: {
        'Content-Type': 'image/jpeg',
      }

The desired content type is set in S3
