### PR TITLE
Pass headers to knox-mpu and auto detect content type if not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ _.defaultsDeep = require('merge-defaults');
 var knox = require('knox');
 var S3MultipartUpload = require('knox-mpu-alt');
 var S3Lister = require('s3-lister');
-
+var mime = require('mime');
 
 /**
  * skipper-s3
@@ -212,11 +212,19 @@ module.exports = function SkipperS3 (globalOpts) {
       // to `.tmp/s3-upload-part-queue`
       options.tmpdir = options.tmpdir || path.resolve(process.cwd(), '.tmp/s3-upload-part-queue');
 
+      var headers = options.headers || {};
+
+      // Lookup content type with mime if not set
+      if ('undefined' === typeof headers['content-type']) {
+        headers['content-type'] = mime.lookup(__newFile.fd);
+      }
+
       var mpu = new S3MultipartUpload({
         objectName: __newFile.fd,
         stream: __newFile,
         maxUploadSize: options.maxBytes,
         tmpDir: options.tmpdir,
+        headers: headers,
         client: knox.createClient({
           key: options.key,
           secret: options.secret,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "knox": "~0.8.9",
     "merge-defaults": "~0.1.0",
     "concat-stream": "~1.4.5",
-    "s3-lister": "~0.1.0"
+    "s3-lister": "~0.1.0",
+    "mime": "~1.2.11"
   }
 }


### PR DESCRIPTION
This is a prop to add support to automatically set the `Content-Type` and pass `headers` to `knox-mpu`

Related to issue #1 and http://stackoverflow.com/questions/25206528/how-to-add-acl-and-content-type-parameters-when-using-skipper-s3

Checked in knox-mpu and seems that there is no need for changes. 

The `mime` package is also used with `knox` but only in a call to `putFile`.
https://github.com/LearnBoost/knox/blob/master/lib/client.js#L363
