### PR TITLE
Allow to set objectName from options

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = function SkipperS3 (globalOpts) {
       }
 
       var mpu = new S3MultipartUpload({
-        objectName: __newFile.fd,
+        objectName: options.objectName || __newFile.fd,
         stream: __newFile,
         maxUploadSize: options.maxBytes,
         tmpDir: options.tmpdir,


### PR DESCRIPTION
By default the objectName is set from the filename, if specified the object will be set from the options.ojectName attribute.
