### PR TITLE
Added a token option in order to support temporary credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ module.exports = function SkipperS3 (globalOpts) {
         secret: globalOpts.secret,
         bucket: globalOpts.bucket,
         region: globalOpts.region||undefined,
-        endpoint: globalOpts.endpoint||undefined
+        endpoint: globalOpts.endpoint||undefined,
+        token: globalOpts.token||undefined
       });
 
       // Build a noop transform stream that will pump the S3 output through
@@ -104,7 +105,8 @@ module.exports = function SkipperS3 (globalOpts) {
         secret: globalOpts.secret,
         bucket: globalOpts.bucket,
         region: globalOpts.region,
-        endpoint: globalOpts.endpoint
+        endpoint: globalOpts.endpoint,
+        token: globalOpts.token||undefined
       });
 
       // TODO: take a look at maxKeys
@@ -230,7 +232,8 @@ module.exports = function SkipperS3 (globalOpts) {
           secret: options.secret,
           bucket: options.bucket,
           region: globalOpts.region||undefined,
-          endpoint: globalOpts.endpoint||undefined
+          endpoint: globalOpts.endpoint||undefined,
+          token: globalOpts.token||undefined
         })
       }, function (err, body) {
         if (err) {


### PR DESCRIPTION
Hi,

Simple change which adds an optional 'token' option to the req.file.upload call. This allows temporary security credentials obtained from the AWS Security Token Service (STS) to be used. The 'token' option is passed through to knox and knox-mpu.

Background in case someone is interested:
When running an EC2 instance with an IAM role assigned you can do a rest call (or use a library like henry or aws-sdk) to the AWS metadata API to obtain temporary security credentials (consisting of key, secret and token) which allow role-based, fine-grained access to specified resources (like S3 buckets). Also, there is then no need to manage explicit security credentials in config or code.

If you decide to use this PR I'd also gladly create one to update the docs at skipper/README.md.

Thanks for the good work on skipper!
Toby
