### PR TITLE
Fixed a TODO in Adapter.rm() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,26 @@ module.exports = function SkipperS3 (globalOpts) {
       return __transform__;
     },
 
-    rm: function (fd, cb){
-      return cb(new Error('TODO'));
+    rm: function (fd, cb) {
+      knox.createClient({
+        key: globalOpts.key,
+        secret: globalOpts.secret,
+        bucket: globalOpts.bucket,
+        region: globalOpts.region||undefined,
+        endpoint: globalOpts.endpoint||undefined
+      })
+        .del(fd)
+        .on('response', function (res) {
+            if (res.statusCode === 200) {
+              cb();
+            } else {
+              cb({
+                statusCode: res.statusCode,
+                message: res.body
+              });
+            }
+          })
+        .end();
     },
     ls: function (dirname, cb) {
       var client = knox.createClient({

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function SkipperS3 (globalOpts) {
       })
         .del(fd)
         .on('response', function (res) {
-            if (res.statusCode === 200) {
+            if (res.statusCode === 204) {
               cb();
             } else {
               cb({


### PR DESCRIPTION
I needed a way to delete objects from s3 as well as test upload/removal. Sins I am already doing `require('skipper-s3')` it's convenient not to write my own knox functions but use and test it like so:

    var skipperS3 = require('skipper-s3');

    skipperS3({
      key: sails.config.aws.key,
      secret: sails.config.aws.secret,
      bucket: sails.config.aws.bucket
    }).rm(fd, function(err) {
       /** ... **/
    });

So I went ahead and fixed that TODO.