### PR TITLE
[implements ACL and S3 response] Add Access Control List option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ req.file('avatar')
   secret: 'AB2g1939eaGAdesoccertournament',
   bucket: 'my_stuff',
   // Optional
-  token: 'temporary_sts_creds'
+  token: 'temporary_sts_creds',
+  ACL: 'file_permission'
 }, function whenDone(err, uploadedFiles) {
   if (err) {
     return res.serverError(err);

--- a/index.js
+++ b/index.js
@@ -225,6 +225,7 @@ function _uploadFile(incomingFd, incomingFileStream, handleProgress, s3ClientOpt
     if (err) {
       return done(err);
     } else {
+      incomingFileStream.extra = rawS3ResponseData;
       return done(undefined, {
         rawS3ResponseData
       });

--- a/index.js
+++ b/index.js
@@ -28,6 +28,23 @@ module.exports = function SkipperS3 (globalOpts) {
 
   return {
 
+    /** 
+    * @param {String} operation: 'getObject' || 'putObject' 
+    * 
+    * @param {Dictionary}
+    *   @property {String} Key
+    *   @property {String} Bucket
+    *   @property {Number} Expires - seconds
+    *   @example { Key: '53429b94853c4efb70740eef/3228796d-fe9b-4762-991e-db0d379fedab.jpg', Bucket: 'my-content'}
+    * 
+    * @returns String
+    * 
+    * @docs -> https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getSignedUrl-property
+    */
+    url: function (operation, params, done) {
+      _buildS3Client(globalOpts).getSignedUrl(operation, params, done);
+    },
+
     read: function (fd) {
       if (arguments[1]) {
         return arguments[1](new Error('For performance reasons, skipper-s3 does not support passing in a callback to `.read()`'));

--- a/index.js
+++ b/index.js
@@ -206,6 +206,7 @@ function _buildS3Client(s3ClientOpts) {
     region: s3ClientOpts.region,
     accessKeyId: s3ClientOpts.key,
     secretAccessKey: s3ClientOpts.secret,
+    ACL: s3ClientOpts.ACL,
     endpoint: s3ClientOpts.endpoint
   });
   return new AWS.S3(s3ConstructorArgins);
@@ -217,6 +218,7 @@ function _uploadFile(incomingFd, incomingFileStream, handleProgress, s3ClientOpt
   .upload(_stripKeysWithUndefinedValues({
     Bucket: s3ClientOpts.bucket,
     Key: incomingFd.replace(/^\/+/, ''),//« remove any leading slashes
+    ACL: s3ClientOpts.ACL,
     Body: incomingFileStream,
     ContentType: mime.getType(incomingFd)//« advisory; makes things nicer in the S3 dashboard
   }), (err, rawS3ResponseData)=>{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skipper-s3",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Stream file uploads, downloads, and transloads to and from S3.  Plus some other utilities like `rm` and `ls`.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skipper-s3",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Stream file uploads, downloads, and transloads to and from S3.  Plus some other utilities like `rm` and `ls`.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
New optional (but really useful) ACL option added 👍 

https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html

And extra attribute is returning now S3 response instead of undefined: 
```javascript
{
  fd: '56c4afec-ec4e-44ce-933b-75dad787168a.jpg',
  size: 44439,
  type: 'image/jpeg',
  filename: 'bj.jpg',
  status: 'finished',
  field: 'image',
  extra:
   { ETag: '"ff10d1b5e2176b9108489d2216f0205a"',
     Location:
      'https://example.s3.amazonaws.com/example/56c4afec-ec4e-44ce-933b-75dad787168a.jpg',
     key: 'demo/56c4afec-ec4e-44ce-933b-75dad787168a.jpg',
     Key: 'demo/56c4afec-ec4e-44ce-933b-75dad787168a.jpg',
     Bucket: 'school-content' } }
```
Which allows to store the location url, for example, after the upload.