### PR TITLE
Add 'ContentDisposition' to parameters sent to s3 client

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,8 @@ function _uploadFile(incomingFd, incomingFileStream, handleProgress, s3ClientOpt
     Bucket: s3ClientOpts.bucket,
     Key: incomingFd.replace(/^\/+/, ''),//« remove any leading slashes
     Body: incomingFileStream,
-    ContentType: mime.getType(incomingFd)//« advisory; makes things nicer in the S3 dashboard
+    ContentType: mime.getType(incomingFd),//« advisory; makes things nicer in the S3 dashboard
+    ContentDisposition: s3ClientOpts.ContentDisposition
   }), (err, rawS3ResponseData)=>{
     if (err) {
       return done(err);


### PR DESCRIPTION
I was not able to pass on the `Content-Disposition` header in any way to the s3 client (I tried with adding `headers['content-disposition']` but it did not work)

After applying this patch, `ContentDisposition` can be added the object passed in as the first parameter to `upload()` function of skipper. This is working as expected